### PR TITLE
Cloudbuild stackdriver-prometheus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *#
 .#*
 *-stamp
-/*.yaml
 /*.yml
 /*.rules
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,6 @@ promu:
 	$(GO) get -u github.com/prometheus/promu
 
 $(FIRST_GOPATH)/bin/staticcheck:
-	@GOOS= GOARCH= $(GO) get -u honnef.co/go/tools/cmd/staticcheck
+	@GOOS= GOARCH= GO111MODULE=on $(GO) get -v honnef.co/go/tools/cmd/staticcheck@release.2017.2
 
 .PHONY: all style check_license format build test vet assets tarball docker promu staticcheck $(FIRST_GOPATH)/bin/staticcheck

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ cd ~/go/src/github.com/Stackdriver/
 git clone git@github.com:overleaf/stackdriver-prometheus.git
 cd stackdriver-prometheus/
 git checkout release-0.5.0
+go get ./...
 make all
 DOCKER_IMAGE_NAME=gcr.io/overleaf-ops/stackdriver-prometheus make push
 ```

--- a/cb.Dockerfile
+++ b/cb.Dockerfile
@@ -1,6 +1,0 @@
-FROM debian
-
-RUN apt-get update && \
-  apt-get install -y build-essential golang-1.8
-
-ENTRYPOINT ["make"]

--- a/cb.Dockerfile
+++ b/cb.Dockerfile
@@ -1,0 +1,6 @@
+FROM debian
+
+RUN apt-get update && \
+  apt-get install -y build-essential golang-1.8
+
+ENTRYPOINT ["make"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,6 @@
 steps:
 - name: 'gcr.io/cloud-builders/go'
-  args: ['fmt', 'github.com/Stackdriver/stackdriver-prometheus/cmd/prometheus', 'github.com/Stackdriver/stackdriver-prometheus/cmd/promtool','github.com/Stackdriver/stackdriver-prometheus/relabel','github.com/Stackdriver/stackdriver-prometheus/retrieval','github.com/Stackdriver/stackdriver-prometheus/stackdriver','github.com/Stackdriver/stackdriver-prometheus/web','github.com/Stackdriver/stackdriver-prometheus/web/api/v1','github.com/Stackdriver/stackdriver-prometheus/web/ui']
+  args: ['all']
   env: ['PROJECT_ROOT=github.com/Stackdriver/stackdriver-prometheus']
-- name: 'gcr.io/cloud-builders/go'
-  args: ['build', '.']
-  env: ['PROJECT_ROOT=github.com/Stackdriver/stackdriver-prometheus']
+  entrypoint: make
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,6 +3,9 @@ steps:
   args: ['all']
   env: ['PROJECT_ROOT=github.com/Stackdriver/stackdriver-prometheus']
   entrypoint: ./go.ash
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/stackdriver-prometheus', '.']
+images: ['gcr.io/$PROJECT_ID/stackdriver-prometheus']
 options:
  diskSizeGb: 200
  machineType: 'N1_HIGHCPU_8'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,4 +3,7 @@ steps:
   args: ['all']
   env: ['PROJECT_ROOT=github.com/Stackdriver/stackdriver-prometheus']
   entrypoint: ./go.ash
+options:
+ diskSizeGb: 200
+ machineType: 'N1_HIGHCPU_8'
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,4 @@
+steps:
+- name: 'gcr.io/cloud-builders/go'
+  args: ['build', '.']
+  env: ['PROJECT_ROOT=Stackdriver/stackdriver-prometheus']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,7 @@
 steps:
 - name: 'gcr.io/cloud-builders/go'
+  args: ['fmt', 'github.com/Stackdriver/stackdriver-prometheus/cmd/prometheus', 'github.com/Stackdriver/stackdriver-prometheus/cmd/promtool','github.com/Stackdriver/stackdriver-prometheus/relabel','github.com/Stackdriver/stackdriver-prometheus/retrieval','github.com/Stackdriver/stackdriver-prometheus/stackdriver','github.com/Stackdriver/stackdriver-prometheus/web','github.com/Stackdriver/stackdriver-prometheus/web/api/v1','github.com/Stackdriver/stackdriver-prometheus/web/ui']
+  env: ['PROJECT_ROOT=github.com/Stackdriver/stackdriver-prometheus']
+- name: 'gcr.io/cloud-builders/go'
   args: ['build', '.']
-  env: ['PROJECT_ROOT=Stackdriver/stackdriver-prometheus']
+  env: ['PROJECT_ROOT=github.com/Stackdriver/stackdriver-prometheus']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/cloud-builders/go'
-  args: ['all']
+  args: ['-C','~/go/src/github.com/Stackdriver/stackdriver-prometheus','all']
   env: ['PROJECT_ROOT=github.com/Stackdriver/stackdriver-prometheus']
-  entrypoint: make
+  entrypoint: ./go.ash
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/cloud-builders/go'
-  args: ['-C','./gopath/src/github.com/Stackdriver/stackdriver-prometheus','all']
+  args: ['all']
   env: ['PROJECT_ROOT=github.com/Stackdriver/stackdriver-prometheus']
   entrypoint: ./go.ash
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/cloud-builders/go'
-  args: ['-C','~/go/src/github.com/Stackdriver/stackdriver-prometheus','all']
+  args: ['-C','./gopath/src/github.com/Stackdriver/stackdriver-prometheus','all']
   env: ['PROJECT_ROOT=github.com/Stackdriver/stackdriver-prometheus']
   entrypoint: ./go.ash
 

--- a/go.ash
+++ b/go.ash
@@ -1,0 +1,5 @@
+#!/bin/ash
+. /builder/prepare_workspace.inc
+prepare_workspace || exit
+echo "Running: make $@"
+make "$@"

--- a/go.ash
+++ b/go.ash
@@ -1,7 +1,10 @@
 #!/bin/ash
-. /builder/prepare_workspace.inc
-prepare_workspace || exit
+export GOPATH=~/go
+mkdir -p $GOPATH/src/github.com/Stackdriver/
+ln -s /workspace/ $GOPATH/src/github.com/Stackdriver/stackdriver-prometheus/
+cd $GOPATH/src/github.com/Stackdriver/stackdriver-prometheus/
 echo "GOPATH is $GOPATH"
+echo "Fetching dependencies"
 go get ./...
 echo "Running: make $@"
 make "$@"

--- a/go.ash
+++ b/go.ash
@@ -1,5 +1,6 @@
 #!/bin/ash
 . /builder/prepare_workspace.inc
 prepare_workspace || exit
+go get ./...
 echo "Running: make $@"
 make "$@"

--- a/go.ash
+++ b/go.ash
@@ -1,7 +1,7 @@
 #!/bin/ash
 export GOPATH=~/go
 mkdir -p $GOPATH/src/github.com/Stackdriver/
-ln -s /workspace/ $GOPATH/src/github.com/Stackdriver/stackdriver-prometheus/
+ln -s /workspace $GOPATH/src/github.com/Stackdriver/stackdriver-prometheus
 cd $GOPATH/src/github.com/Stackdriver/stackdriver-prometheus/
 echo "GOPATH is $GOPATH"
 echo "Fetching dependencies"

--- a/go.ash
+++ b/go.ash
@@ -1,6 +1,7 @@
 #!/bin/ash
 . /builder/prepare_workspace.inc
 prepare_workspace || exit
+echo "GOPATH is $GOPATH"
 go get ./...
 echo "Running: make $@"
 make "$@"


### PR DESCRIPTION
We'll need to rebuild `stackdriver-prometheus` and the underlying `quay.io/prometheus/busybox` to use a newer `busybox:uclibc` image to eliminate CVE - CVE-2019-5021. I thought it might be interesting to try using cloud builder for this as an alternative to building locally and uploading the image.